### PR TITLE
Bug fixes for mutect2 somatic calling workflow wrapper

### DIFF
--- a/janis_bioinformatics/tools/bcftools/concat/base.py
+++ b/janis_bioinformatics/tools/bcftools/concat/base.py
@@ -34,7 +34,7 @@ class BcfToolsConcatBase(BcfToolsToolBase, ABC):
             ToolInput("vcf", Array(CompressedVcf()), position=15),
             ToolInput(
                 "outputFilename",
-                Filename(extension=".vcf"),
+                Filename(extension=".vcf.gz"),
                 prefix="-o",
                 doc="--output: When output consists of a single stream, "
                 "write it to FILE rather than to standard output, where it is written by default.",
@@ -121,6 +121,7 @@ if the BCF headers differ.
             "outputType",
             String(optional=True),
             prefix="-O",
+            default="z",
             doc="--output-type b|u|z|v: Output compressed BCF (b), uncompressed BCF (u), "
             "compressed VCF (z), uncompressed VCF (v). Use the -Ou option when piping "
             "between bcftools subcommands to speed up performance by removing "

--- a/janis_bioinformatics/tools/gatk4/getpileupsummaries/base.py
+++ b/janis_bioinformatics/tools/gatk4/getpileupsummaries/base.py
@@ -62,6 +62,7 @@ class Gatk4GetPileUpSummariesBase(Gatk4ToolBase, ABC):
                 "bam",
                 Array(BamBai()),
                 prefix="-I",
+		prefix_applies_to_all_elements=True,
                 doc="The SAM/BAM/CRAM file containing reads.",
                 position=0,
             ),
@@ -102,7 +103,7 @@ class Gatk4GetPileUpSummariesBase(Gatk4ToolBase, ABC):
         val = get_value_for_hints_and_ordered_resource_tuple(hints, MEM_TUPLE)
         if val:
             return val
-        return 8
+        return 64
 
     additional_args = []
 

--- a/janis_bioinformatics/tools/gatk4/mutect2/base_4_1.py
+++ b/janis_bioinformatics/tools/gatk4/mutect2/base_4_1.py
@@ -89,7 +89,7 @@ class Gatk4Mutect2Base_4_1(Gatk4ToolBase, ABC):
             ToolInput(
                 tag="normalSample",
                 input_type=String,
-                prefix="-normalBAM",
+                prefix="--normal-sample",
                 doc="(--normal-sample, if) May be URL-encoded as output by GetSampleName with",
             ),
             ToolInput(
@@ -896,6 +896,18 @@ class Gatk4Mutect2Base_4_1(Gatk4ToolBase, ABC):
                 doc="To determine type",
             ),
         ]
+
+    def cpus(self, hints: Dict[str, Any]):
+        val = get_value_for_hints_and_ordered_resource_tuple(hints, CORES_TUPLE)
+        if val:
+            return val
+        return 4
+
+    def memory(self, hints: Dict[str, Any]):
+        val = get_value_for_hints_and_ordered_resource_tuple(hints, MEM_TUPLE)
+        if val:
+            return val
+        return 8
 
     def bind_metadata(self):
         from datetime import date


### PR DESCRIPTION
Hey,
These are the changes I propose to improve the tools

concat should output compressed vcfs as a default in my opinion, as janis will not allow streaming of files, so the default to output to textfile does not make sense.

pileupsummaries needs to have -I in front of all the inputs, so this is a bug fix.

Mutect2 defaultly uses 4 threads to calculate the models and from my preliminary analysis it looks like it is much faster that way. So this is a suggestion to set the defaults to 4.
Also there is a bugfix hidden in the change, that I forgot to mention in the commit, where the --normal-sample parameter did not have the right name.

Cheers,
Sebastian