### PR TITLE
added the somaticSV output to the wrapper

### DIFF
--- a/janis_bioinformatics/tools/illumina/manta/base.py
+++ b/janis_bioinformatics/tools/illumina/manta/base.py
@@ -124,6 +124,11 @@ class MantaBase(IlluminaToolBase, ABC):
                 Tsv(),
                 glob=InputSelector("runDir") + "/results/stats/svLocusGraphStats.tsv",
             ),
+            ToolOutput(
+                "somaticSV",
+                VcfTabix(),
+                glob=InputSelector("runDir") + "/results/variants/somaticSV.vcf.gz",
+            ),
         ]
 
     def arguments(self) -> List[ToolArgument]:


### PR DESCRIPTION
somaticSV.vcf.gz
SVs and indels scored under a somatic variant model. This file will only be produced if a tumor sample alignment file is supplied during configuration