### PR TITLE
add compressed fasta datatypes

### DIFF
--- a/janis_bioinformatics/data_types/fasta.py
+++ b/janis_bioinformatics/data_types/fasta.py
@@ -78,7 +78,7 @@ class FastaGz(File):
 
     def can_receive_from(self, other, source_has_default=False):
 
-        if isinstance(other, Fasta):
+        if isinstance(other, FastaGz):
             if other.optional and not self.optional:
                 return False
         elif not super().can_receive_from(other, source_has_default):

--- a/janis_bioinformatics/data_types/fasta.py
+++ b/janis_bioinformatics/data_types/fasta.py
@@ -37,7 +37,7 @@ class FastaFai(Fasta):
 class FastaBwa(Fasta):
     @staticmethod
     def name():
-        return "FastaFai"
+        return "FastaBwa"
 
     @staticmethod
     def secondary_files():
@@ -65,6 +65,69 @@ class FastaWithIndexes(Fasta):
 
 
 FastaWithDict = FastaWithIndexes
+
+
+class FastaGz(File):
+    def __init__(self, optional=False):
+        super().__init__(optional, extension=".fa.gz")
+
+    @staticmethod
+    def name():
+        return "FastaGz"
+
+    def can_receive_from(self, other, source_has_default=False):
+
+        if isinstance(other, Fasta):
+            if other.optional and not self.optional:
+                return False
+        elif not super().can_receive_from(other, source_has_default):
+            return False
+
+        if not self.secondary_files():
+            return True
+
+        return set(self.secondary_files()).issubset(set(other.secondary_files() or []))
+
+
+class FastaGzFai(FastaGz):
+    @staticmethod
+    def name():
+        return "FastaGzFai"
+
+    @staticmethod
+    def secondary_files():
+        return [".fai"]
+
+
+class FastaGzBwa(FastaGz):
+    @staticmethod
+    def name():
+        return "FastaGzBwa"
+
+    @staticmethod
+    def secondary_files():
+        return [".amb", ".ann", ".bwt", ".pac", ".sa"]
+
+
+class FastaGzDict(FastaGzFai):
+    @staticmethod
+    def name():
+        return "FastGzDict"
+
+    @staticmethod
+    def secondary_files():
+        return [*super().secondary_files(), "^.dict"]
+
+
+class FastaGzWithIndexes(FastaGz):
+    @staticmethod
+    def name():
+        return "FastaGzWithIndexes"
+
+    @staticmethod
+    def secondary_files():
+        return [*FastaGzBwa.secondary_files(), *FastaGzDict.secondary_files()]
+
 
 if __name__ == "__main__":
     bwa, fai, wdict = FastaBwa(), FastaFai(), FastaWithDict()

--- a/janis_bioinformatics/data_types/fasta.py
+++ b/janis_bioinformatics/data_types/fasta.py
@@ -51,7 +51,7 @@ class FastaDict(FastaFai):
 
     @staticmethod
     def secondary_files():
-        return [*FastaFai().secondary_files(), "^.dict"]
+        return [*FastaFai.secondary_files(), "^.dict"]
 
 
 class FastaWithIndexes(Fasta):
@@ -116,7 +116,7 @@ class FastaGzDict(FastaGzFai):
 
     @staticmethod
     def secondary_files():
-        return [*super().secondary_files(), "^.dict"]
+        return [*FastaGzFai.secondary_files(), "^.dict"]
 
 
 class FastaGzWithIndexes(FastaGz):

--- a/janis_bioinformatics/data_types/fasta.py
+++ b/janis_bioinformatics/data_types/fasta.py
@@ -51,7 +51,7 @@ class FastaDict(FastaFai):
 
     @staticmethod
     def secondary_files():
-        return [*super().secondary_files(), "^.dict"]
+        return [*FastaFai().secondary_files(), "^.dict"]
 
 
 class FastaWithIndexes(Fasta):


### PR DESCRIPTION
New datatype for compressed fasta references.
This ties is with your work for VEP, because VEP is impossibly slow when using an uncompressed reference.

Cheers
M