### PR TITLE
fix import so janis inputs works.

### DIFF
--- a/janis_bioinformatics/tools/dawson/workflows/mutectjointsomaticworkflow.py
+++ b/janis_bioinformatics/tools/dawson/workflows/mutectjointsomaticworkflow.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-from janis import Array, String
+from janis_core import Array, String
 from janis_bioinformatics.data_types import CramCrai, FastaWithDict, VcfTabix
 from janis_bioinformatics.tools import BioinformaticsWorkflow
 from janis_bioinformatics.tools.bcftools import (


### PR DESCRIPTION
Running `janis inputs` fails because it can't find `janis`. This change picks it up from `janis_core` instead.