### PR TITLE
Bug fix in addbamstats

### DIFF
--- a/janis_bioinformatics/tools/pmac/addBamStatsGermlineWorkflow.py
+++ b/janis_bioinformatics/tools/pmac/addBamStatsGermlineWorkflow.py
@@ -2,6 +2,7 @@ from janis_core import WorkflowBuilder, WorkflowMetadata
 
 # data types
 from janis_bioinformatics.data_types import Vcf, BamBai
+from janis_bioinformatics.data_types import FastaWithDict
 
 from janis_core import String
 
@@ -32,12 +33,14 @@ class AddBamStatsGermline_0_1_0(BioinformaticsWorkflow):
         # self.input("sample_name", String)
         self.input("bam", BamBai)
         self.input("vcf", Vcf)
+        self.input("reference", FastaWithDict)
 
         self.step(
             "samtoolsmpileup",
             SamToolsMpileupLatest(
                 bam=self.bam,
                 positions=self.vcf,
+                reference=self.reference,
                 countOrphans=True,
                 noBAQ=True,
                 minBQ=0,

--- a/janis_bioinformatics/tools/pmac/addBamStatsSomaticWorkflow.py
+++ b/janis_bioinformatics/tools/pmac/addBamStatsSomaticWorkflow.py
@@ -2,6 +2,7 @@ from janis_core import WorkflowBuilder, WorkflowMetadata
 
 # data types
 from janis_bioinformatics.data_types import Vcf, BamBai
+from janis_bioinformatics.data_types import FastaWithDict
 
 from janis_core import String
 
@@ -33,14 +34,21 @@ class AddBamStatsSomatic_0_1_0(BioinformaticsWorkflow):
         self.input("tumor_id", String)
         self.input("normal_bam", BamBai)
         self.input("tumor_bam", BamBai)
+        self.input("reference", FastaWithDict)
         self.input("vcf", Vcf)
 
         self.step(
-            "tumor", self.process_subpipeline(vcf=self.vcf, bam=self.tumor_bam,),
+            "tumor",
+            self.process_subpipeline(
+                vcf=self.vcf, bam=self.tumor_bam, reference=self.reference,
+            ),
         )
 
         self.step(
-            "normal", self.process_subpipeline(vcf=self.vcf, bam=self.normal_bam,),
+            "normal",
+            self.process_subpipeline(
+                vcf=self.vcf, bam=self.normal_bam, reference=self.reference,
+            ),
         )
 
         self.step(
@@ -67,11 +75,13 @@ class AddBamStatsSomatic_0_1_0(BioinformaticsWorkflow):
         w = WorkflowBuilder("samtools_mpileup_subpipeline")
         w.input("vcf", Vcf)
         w.input("bam", BamBai)
+        w.input("reference", FastaWithDict)
         w.step(
             "samtools_mpileup",
             SamToolsMpileupLatest(
                 bam=w.bam,
                 positions=w.vcf,
+                reference=w.reference,
                 countOrphans=True,
                 noBAQ=True,
                 minBQ=0,

--- a/janis_bioinformatics/tools/pmac/molpathGermlineWorkflow.py
+++ b/janis_bioinformatics/tools/pmac/molpathGermlineWorkflow.py
@@ -165,7 +165,9 @@ class MolpathGermline_1_0_0(BioinformaticsWorkflow):
         self.step(
             "addbamstats",
             AddBamStatsGermline_0_1_0(
-                bam=self.merge_and_mark.out, vcf=self.splitnormalisevcf.out
+                bam=self.merge_and_mark.out,
+                vcf=self.splitnormalisevcf.out,
+                reference=self.reference,
             ),
         )
         # output

--- a/janis_bioinformatics/tools/pmac/molpathTumorOnlyWorkflow.py
+++ b/janis_bioinformatics/tools/pmac/molpathTumorOnlyWorkflow.py
@@ -213,7 +213,9 @@ class MolpathTumorOnly_1_0_0(BioinformaticsWorkflow):
         self.step(
             "addbamstats",
             AddBamStatsGermline_0_1_0(
-                bam=self.merge_and_mark.out, vcf=self.uncompressvcf.out
+                bam=self.merge_and_mark.out,
+                vcf=self.uncompressvcf.out,
+                reference=self.reference,
             ),
         )
         # Molpath specific processes

--- a/janis_bioinformatics/tools/variantcallers/gatk/gatkgermline_variants_4_0_12.py
+++ b/janis_bioinformatics/tools/variantcallers/gatk/gatkgermline_variants_4_0_12.py
@@ -94,7 +94,9 @@ class GatkGermlineVariantCaller_4_0_12(BioinformaticsWorkflow):
         )
         self.step(
             "addbamstats",
-            AddBamStatsGermline_0_1_0(bam=self.bam, vcf=self.splitnormalisevcf.out),
+            AddBamStatsGermline_0_1_0(
+                bam=self.bam, vcf=self.splitnormalisevcf.out, reference=self.reference
+            ),
         )
 
         self.output("variants", source=self.haplotype_caller.out)

--- a/janis_bioinformatics/tools/variantcallers/gatk/gatksomatic_variants_single.py
+++ b/janis_bioinformatics/tools/variantcallers/gatk/gatksomatic_variants_single.py
@@ -1,10 +1,7 @@
 from datetime import date
 
-from janis_core import String, WorkflowBuilder, Array
 from janis_bioinformatics.tools import gatk4
 from janis_bioinformatics.tools.common import SplitMultiAlleleNormaliseVcf
-from janis_bioinformatics.tools.vcftools import VcfToolsvcftoolsLatest
-from janis_bioinformatics.tools.pmac import AddBamStatsSomatic_0_1_0
 from janis_bioinformatics.data_types import FastaWithDict, BamBai, VcfTabix, Bed
 from janis_bioinformatics.tools import BioinformaticsWorkflow
 


### PR DESCRIPTION
Hi Michael,
I found a bug in the samtools mpileup in add bam stats step. The python script must use the mpileup output *with the reference*, otherwise it can't produce correct statistics.
I'll create another pull request to correct the janis-pipelines.
Sorry about the inconvinience.
Thanks,
Jiaan
FYI @rlupat 