### PR TITLE
Change reference type for a few tools

### DIFF
--- a/janis_bioinformatics/tools/bcftools/norm/base.py
+++ b/janis_bioinformatics/tools/bcftools/norm/base.py
@@ -11,7 +11,7 @@ from janis_core import (
     ToolOutput,
     InputSelector,
 )
-from janis_bioinformatics.data_types import FastaWithDict, CompressedVcf
+from janis_bioinformatics.data_types import FastaFai, CompressedVcf
 from janis_bioinformatics.data_types import Vcf
 from janis_bioinformatics.tools.bcftools.bcftoolstoolbase import BcfToolsToolBase
 from janis_core import ToolMetadata
@@ -57,9 +57,9 @@ class BcfToolsNormBase(BcfToolsToolBase, ABC):
             "https://samtools.github.io/bcftools/bcftools.html#norm"
         )
         self.metadata.documentation = """\
-Left-align and normalize indels, check if REF alleles match the reference, 
-split multiallelic sites into multiple rows; recover multiallelics from 
-multiple rows. Left-alignment and normalization will only be applied if 
+Left-align and normalize indels, check if REF alleles match the reference,
+split multiallelic sites into multiple rows; recover multiallelics from
+multiple rows. Left-alignment and normalization will only be applied if
 the --fasta-ref option is supplied.
 """
 
@@ -92,7 +92,7 @@ the --fasta-ref option is supplied.
         ),
         ToolInput(
             "reference",
-            FastaWithDict(optional=True),
+            FastaFai(optional=True),
             prefix="-f",
             doc="--fasta-ref: reference sequence. Supplying this option will turn on left-alignment and "
             "normalization, however, see also the --do-not-normalize option below.",

--- a/janis_bioinformatics/tools/dawson/workflows/freebayessomaticworkflow.py
+++ b/janis_bioinformatics/tools/dawson/workflows/freebayessomaticworkflow.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-from janis_bioinformatics.data_types import CramCrai, FastaWithDict
+from janis_bioinformatics.data_types import CramCrai, FastaFai
 from janis_bioinformatics.tools import BioinformaticsWorkflow
 from janis_bioinformatics.tools.bcftools import BcfToolsNormLatest as BcfToolsNorm
 from janis_bioinformatics.tools.dawson import (
@@ -56,7 +56,7 @@ class FreeBayesSomaticWorkflow(BioinformaticsWorkflow):
 
         self.input("bams", Array(CramCrai))
 
-        self.input("reference", FastaWithDict)
+        self.input("reference", FastaFai)
         self.input("regionSize", int, default=10000000)
 
         self.input("normalSample", String)

--- a/janis_bioinformatics/tools/dawson/workflows/mutectjointsomaticworkflow.py
+++ b/janis_bioinformatics/tools/dawson/workflows/mutectjointsomaticworkflow.py
@@ -1,7 +1,7 @@
 from datetime import date
 
 from janis_core import Array, String
-from janis_bioinformatics.data_types import CramCrai, FastaWithDict, VcfTabix
+from janis_bioinformatics.data_types import CramCrai, FastaFai, VcfTabix
 from janis_bioinformatics.tools import BioinformaticsWorkflow
 from janis_bioinformatics.tools.bcftools import (
     BcfToolsConcat_1_9 as BcfToolsConcat,
@@ -67,7 +67,7 @@ class Mutect2JointSomaticWorkflow(BioinformaticsWorkflow):
 
         self.input("biallelicSites", VcfTabix)
 
-        self.input("reference", FastaWithDict)
+        self.input("reference", FastaFai)
 
         self.input("regionSize", int, default=10000000)
 

--- a/janis_bioinformatics/tools/dawson/workflows/mutectjointsomaticworkflow.py
+++ b/janis_bioinformatics/tools/dawson/workflows/mutectjointsomaticworkflow.py
@@ -1,7 +1,7 @@
 from datetime import date
 
 from janis_core import Array, String
-from janis_bioinformatics.data_types import CramCrai, FastaFai, VcfTabix
+from janis_bioinformatics.data_types import CramCrai, FastaWithDict, VcfTabix
 from janis_bioinformatics.tools import BioinformaticsWorkflow
 from janis_bioinformatics.tools.bcftools import (
     BcfToolsConcat_1_9 as BcfToolsConcat,
@@ -67,7 +67,7 @@ class Mutect2JointSomaticWorkflow(BioinformaticsWorkflow):
 
         self.input("biallelicSites", VcfTabix)
 
-        self.input("reference", FastaFai)
+        self.input("reference", FastaWithDict)
 
         self.input("regionSize", int, default=10000000)
 

--- a/janis_bioinformatics/tools/dawson/workflows/mutectjointsomaticworkflow.py
+++ b/janis_bioinformatics/tools/dawson/workflows/mutectjointsomaticworkflow.py
@@ -111,6 +111,7 @@ class Mutect2JointSomaticWorkflow(BioinformaticsWorkflow):
                 bam=self.tumorBams,
                 sites=self.biallelicSites,
                 intervals=self.biallelicSites,
+                reference=self.reference,
             ),
         )
 

--- a/janis_bioinformatics/tools/freebayes/base_1_2.py
+++ b/janis_bioinformatics/tools/freebayes/base_1_2.py
@@ -17,7 +17,7 @@ from janis_core import (
 )
 from janis_unix import TextFile
 
-from janis_bioinformatics.data_types import BamBai, Bed, FastaWithDict, Vcf
+from janis_bioinformatics.data_types import BamBai, Bed, FastaFai, Vcf
 from janis_bioinformatics.tools.bioinformaticstoolbase import BioinformaticsTool
 
 CORES_TUPLE = [
@@ -79,7 +79,7 @@ class FreeBayesBase_1_2(BioinformaticsTool):
             ),
             ToolInput(
                 tag="reference",
-                input_type=FastaWithDict(),
+                input_type=FastaFai(),
                 prefix="-f",
                 doc=" Use FILE as the reference sequence for analysis. An index file (FILE.fai) will be created if none exists. If neither --targets nor --region are specified, FreeBayes will analyze every position in this reference.",
             ),

--- a/janis_bioinformatics/tools/freebayes/base_1_3.py
+++ b/janis_bioinformatics/tools/freebayes/base_1_3.py
@@ -1,6 +1,6 @@
 from typing import Dict, Any
 
-from janis_bioinformatics.data_types import BamBai, Bed, FastaWithDict, Vcf
+from janis_bioinformatics.data_types import BamBai, Bed, FastaFai, Vcf
 from janis_bioinformatics.tools.bioinformaticstoolbase import BioinformaticsTool
 from janis_core import (
     Array,
@@ -78,7 +78,7 @@ class FreeBayesBase_1_3(BioinformaticsTool):
             ),
             ToolInput(
                 tag="reference",
-                input_type=FastaWithDict(),
+                input_type=FastaFai(),
                 prefix="-f",
                 doc=" Use FILE as the reference sequence for analysis. An index file (FILE.fai) will be created if none exists. If neither --targets nor --region are specified, FreeBayes will analyze every position in this reference.",
             ),

--- a/janis_bioinformatics/tools/gatk4/getpileupsummaries/base.py
+++ b/janis_bioinformatics/tools/gatk4/getpileupsummaries/base.py
@@ -14,7 +14,7 @@ from janis_core import (
 )
 from janis_unix import TextFile
 
-from janis_bioinformatics.data_types import BamBai, VcfIdx, Bed, VcfTabix
+from janis_bioinformatics.data_types import BamBai, VcfIdx, Bed, VcfTabix, FastaFai
 from ..gatk4toolbase import Gatk4ToolBase
 
 CORES_TUPLE = [
@@ -79,6 +79,12 @@ class Gatk4GetPileUpSummariesBase(Gatk4ToolBase, ABC):
             ),
             ToolInput(
                 "pileupTableOut", Filename(extension=".txt"), position=1, prefix="-O"
+            ),
+            ToolInput(
+                reference,
+                FastaFai(optional=True),
+                prefix="-R",
+                doc="reference to use when decoding CRAMS",
             ),
         ]
 

--- a/janis_bioinformatics/tools/gatk4/getpileupsummaries/base.py
+++ b/janis_bioinformatics/tools/gatk4/getpileupsummaries/base.py
@@ -81,7 +81,7 @@ class Gatk4GetPileUpSummariesBase(Gatk4ToolBase, ABC):
                 "pileupTableOut", Filename(extension=".txt"), position=1, prefix="-O"
             ),
             ToolInput(
-                reference,
+                "reference",
                 FastaFai(optional=True),
                 prefix="-R",
                 doc="reference to use when decoding CRAMS",

--- a/janis_bioinformatics/tools/illumina/manta/base.py
+++ b/janis_bioinformatics/tools/illumina/manta/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Dict, Any, List
 
-from janis_bioinformatics.data_types import BamBai, BedTabix, FastaWithDict, VcfTabix
+from janis_bioinformatics.data_types import BamBai, BedTabix, FastaFai, VcfTabix
 from janis_bioinformatics.tools.illumina.illuminabase import IlluminaToolBase
 from janis_core import (
     Boolean,
@@ -208,7 +208,7 @@ of capabilities and limitations.""".strip(),
         ),
         ToolInput(
             "reference",
-            FastaWithDict(),
+            FastaFai(),
             prefix="--referenceFasta",
             position=1,
             shell_quote=False,

--- a/janis_bioinformatics/tools/illumina/strelkasomatic/base.py
+++ b/janis_bioinformatics/tools/illumina/strelkasomatic/base.py
@@ -2,7 +2,7 @@ from abc import ABC
 from datetime import datetime
 from typing import Dict, Any
 
-from janis_bioinformatics.data_types import BamBai, BedTabix, FastaWithDict, VcfTabix
+from janis_bioinformatics.data_types import BamBai, BedTabix, FastaFai, VcfTabix
 from janis_bioinformatics.tools.illumina.illuminabase import IlluminaToolBase
 from janis_core import (
     Array,
@@ -118,7 +118,7 @@ class StrelkaSomaticBase(IlluminaToolBase, ABC):
             ),
             ToolInput(
                 tag="reference",
-                input_type=FastaWithDict(),
+                input_type=FastaFai(),
                 prefix="--referenceFasta=",
                 position=1,
                 separate_value_from_prefix=False,


### PR DESCRIPTION
most tools only require a fasta with fai index. 
This relaxes requirements quite a lot