### PR TITLE
creating the latest versions for tools

### DIFF
--- a/janis_bioinformatics/tools/dawson/workflows/mutectjointsomaticworkflow.py
+++ b/janis_bioinformatics/tools/dawson/workflows/mutectjointsomaticworkflow.py
@@ -16,11 +16,11 @@ from janis_bioinformatics.tools.gatk4 import (
     Gatk4MergeMutectStatsLatest as MergeMutectStats,
 )
 from janis_bioinformatics.tools.gatk4.mutect2.versions import (
-    GatkMutect2CramLatest as Mutect2,
+    GatkMutect2Cram_4_1_6 as Mutect2,
 )
 
 from janis_bioinformatics.tools.gatk4.getpileupsummaries.versions import (
-    Gatk4GetPileUpSummariesCramLatest as GetPileUpSummaries,
+    Gatk4GetPileUpSummariesCram_4_1_6 as GetPileUpSummaries,
 )
 
 

--- a/janis_bioinformatics/tools/dawson/workflows/mutectjointsomaticworkflow.py
+++ b/janis_bioinformatics/tools/dawson/workflows/mutectjointsomaticworkflow.py
@@ -10,17 +10,17 @@ from janis_bioinformatics.tools.bcftools import (
 )
 from janis_bioinformatics.tools.dawson.createcallregions.base import CreateCallRegions
 from janis_bioinformatics.tools.gatk4 import (
-    Gatk4CalculateContamination_4_1_4 as CalculateContamination,
-    Gatk4FilterMutectCalls_4_1_4 as FilterMutectCalls,
-    Gatk4LearnReadOrientationModel_4_1_4 as LearnReadOrientationModel,
-    Gatk4MergeMutectStats_4_1_2 as MergeMutectStats,
+    Gatk4CalculateContaminationLatest as CalculateContamination,
+    Gatk4FilterMutectCallsLatest as FilterMutectCalls,
+    Gatk4LearnReadOrientationModelLatest as LearnReadOrientationModel,
+    Gatk4MergeMutectStatsLatest as MergeMutectStats,
 )
 from janis_bioinformatics.tools.gatk4.mutect2.versions import (
-    GatkMutect2Cram_4_1_4 as Mutect2,
+    GatkMutect2CramLatest as Mutect2,
 )
 
 from janis_bioinformatics.tools.gatk4.getpileupsummaries.versions import (
-    Gatk4GetPileUpSummariesCram_4_1_4 as GetPileUpSummaries,
+    Gatk4GetPileUpSummariesCramLatest as GetPileUpSummaries,
 )
 
 

--- a/janis_bioinformatics/tools/gatk4/getpileupsummaries/base.py
+++ b/janis_bioinformatics/tools/gatk4/getpileupsummaries/base.py
@@ -14,7 +14,7 @@ from janis_core import (
 )
 from janis_unix import TextFile
 
-from janis_bioinformatics.data_types import BamBai, VcfIdx, Bed, VcfTabix, FastaFai
+from janis_bioinformatics.data_types import BamBai, VcfIdx, Bed, VcfTabix, FastaWithDict
 from ..gatk4toolbase import Gatk4ToolBase
 
 CORES_TUPLE = [
@@ -82,7 +82,7 @@ class Gatk4GetPileUpSummariesBase(Gatk4ToolBase, ABC):
             ),
             ToolInput(
                 "reference",
-                FastaFai(optional=True),
+                FastaWithDict(optional=True),
                 prefix="-R",
                 doc="reference to use when decoding CRAMS",
             ),

--- a/janis_bioinformatics/tools/gatk4/getpileupsummaries/versions.py
+++ b/janis_bioinformatics/tools/gatk4/getpileupsummaries/versions.py
@@ -1,6 +1,6 @@
 from .base import Gatk4GetPileUpSummariesBase
 from .base_cram import Gatk4GetPileUpSummariesCramBase
-from ..versions import Gatk_4_1_2_0, Gatk_4_1_3_0, Gatk_4_1_4_0
+from ..versions import Gatk_4_1_2_0, Gatk_4_1_3_0, Gatk_4_1_4_0, Gatk_4_1_6_0
 
 
 class Gatk4GetPileUpSummaries_4_1_2(Gatk_4_1_2_0, Gatk4GetPileUpSummariesBase):
@@ -12,6 +12,10 @@ class Gatk4GetPileUpSummaries_4_1_3(Gatk_4_1_3_0, Gatk4GetPileUpSummariesBase):
 
 
 class Gatk4GetPileUpSummaries_4_1_4(Gatk_4_1_4_0, Gatk4GetPileUpSummariesBase):
+    pass
+
+
+class Gatk4GetPileUpSummaries_4_1_6(Gatk_4_1_6_0, Gatk4GetPileUpSummariesBase):
     pass
 
 
@@ -31,7 +35,7 @@ class Gatk4GetPileUpSummariesCram_4_1_6(Gatk_4_1_6_0, Gatk4GetPileUpSummariesCra
     pass
 
 
-Gatk4GetPileUpSummariesLatest = Gatk4GetPileUpSummaries_4_1_4
+Gatk4GetPileUpSummariesLatest = Gatk4GetPileUpSummaries_4_1_6
 
 if __name__ == "__main__":
     print(Gatk4GetPileUpSummariesBase().help())

--- a/janis_bioinformatics/tools/gatk4/getpileupsummaries/versions.py
+++ b/janis_bioinformatics/tools/gatk4/getpileupsummaries/versions.py
@@ -27,6 +27,10 @@ class Gatk4GetPileUpSummariesCram_4_1_4(Gatk_4_1_4_0, Gatk4GetPileUpSummariesCra
     pass
 
 
+class Gatk4GetPileUpSummariesCram_4_1_6(Gatk_4_1_6_0, Gatk4GetPileUpSummariesCramBase):
+    pass
+
+
 Gatk4GetPileUpSummariesLatest = Gatk4GetPileUpSummaries_4_1_4
 
 if __name__ == "__main__":

--- a/janis_bioinformatics/tools/gatk4/mutect2/versions.py
+++ b/janis_bioinformatics/tools/gatk4/mutect2/versions.py
@@ -2,7 +2,13 @@ from .base_4_0 import Gatk4Mutect2Base_4_0
 from .base_4_1 import Gatk4Mutect2Base_4_1
 from .base_4_1_cram import Gatk4Mutect2CramBase_4_1
 
-from ..versions import Gatk_4_0_12, Gatk_4_1_2_0, Gatk_4_1_3_0, Gatk_4_1_4_0
+from ..versions import (
+    Gatk_4_0_12,
+    Gatk_4_1_2_0,
+    Gatk_4_1_3_0,
+    Gatk_4_1_4_0,
+    Gatk_4_1_6_0,
+)
 
 
 class GatkMutect2_4_0(Gatk_4_0_12, Gatk4Mutect2Base_4_0):
@@ -18,6 +24,10 @@ class GatkMutect2_4_1_3(Gatk_4_1_3_0, Gatk4Mutect2Base_4_1):
 
 
 class GatkMutect2_4_1_4(Gatk_4_1_4_0, Gatk4Mutect2Base_4_1):
+    pass
+
+
+class GatkMutect2_4_1_6(Gatk_4_1_6_0, Gatk4Mutect2Base_4_1):
     pass
 
 
@@ -37,7 +47,7 @@ class GatkMutect2Cram_4_1_6(Gatk_4_1_6_0, Gatk4Mutect2CramBase_4_1):
     pass
 
 
-GatkMutect2Latest = GatkMutect2_4_1_4
+GatkMutect2Latest = GatkMutect2_4_1_6
 
 if __name__ == "__main__":
     print(GatkMutect2_4_0().help())

--- a/janis_bioinformatics/tools/gatk4/mutect2/versions.py
+++ b/janis_bioinformatics/tools/gatk4/mutect2/versions.py
@@ -33,6 +33,10 @@ class GatkMutect2Cram_4_1_4(Gatk_4_1_4_0, Gatk4Mutect2CramBase_4_1):
     pass
 
 
+class GatkMutect2Cram_4_1_6(Gatk_4_1_6_0, Gatk4Mutect2CramBase_4_1):
+    pass
+
+
 GatkMutect2Latest = GatkMutect2_4_1_4
 
 if __name__ == "__main__":


### PR DESCRIPTION
creating normal and cram input versions for mutect2 

reverting pileup back to FastaWithDict, because the new version requires that