### PR TITLE
optimisations

### DIFF
--- a/janis_bioinformatics/tools/dawson/dawsontoolkit_0_1.py
+++ b/janis_bioinformatics/tools/dawson/dawsontoolkit_0_1.py
@@ -8,8 +8,8 @@ class DawsonToolkit_0_1(CommandTool, ABC):
 
     @staticmethod
     def container():
-        return "shollizeck/dawsontoolkit:0.1.7.1"
+        return "shollizeck/dawsontoolkit:0.1.8"
 
     @staticmethod
     def version():
-        return "0.1.7"
+        return "0.1.8"

--- a/janis_bioinformatics/tools/dawson/refilterstrelka2calls/base.py
+++ b/janis_bioinformatics/tools/dawson/refilterstrelka2calls/base.py
@@ -114,6 +114,13 @@ class RefilterStrelka2CallsBase(BioinformaticsTool, ABC):
                 doc="minimum phred scaled evidence for a variant to be accepted (default: 20)",
             ),
             ToolInput(
+                tag="minAD",
+                input_type=Int(),
+                default=2,
+                prefix="--minAD",
+                doc="minimum allelic depth for a variant to be accepted (default: 2)",
+            ),
+            ToolInput(
                 tag="threads",
                 input_type=Int(),
                 default=CpuSelector(),

--- a/janis_bioinformatics/tools/dawson/workflows/strelka2passworkflow.py
+++ b/janis_bioinformatics/tools/dawson/workflows/strelka2passworkflow.py
@@ -111,7 +111,9 @@ class Strelka2PassWorkflow(BioinformaticsWorkflow):
         self.step(
             "refilterINDELs",
             RefilterStrelka2Calls(
-                inputFiles=self.step2.indels, sampleNames=self.sampleNames
+                inputFiles=self.step2.indels,
+                sampleNames=self.sampleNames,
+                minAD=self.minAD,
             ),
         )
         self.step("compressINDELs", BGZip(file=self.refilterINDELs.out), scatter="file")

--- a/janis_bioinformatics/tools/dawson/workflows/strelka2passworkflow.py
+++ b/janis_bioinformatics/tools/dawson/workflows/strelka2passworkflow.py
@@ -12,7 +12,7 @@ from janis_bioinformatics.tools.dawson.workflows.strelka2passanalysisstep2 impor
     Strelka2PassWorkflowStep2,
 )
 from janis_bioinformatics.tools.htslib import BGZipLatest as BGZip, TabixLatest as Tabix
-from janis_core import Array, Boolean, String, File
+from janis_core import Array, Boolean, String, File, Int
 from janis_bioinformatics.data_types import VcfTabix
 
 
@@ -65,6 +65,7 @@ class Strelka2PassWorkflow(BioinformaticsWorkflow):
         self.input("exome", Boolean(optional=True), default=False)
 
         self.input("sampleNames", Array(String, optional=True))
+        self.input("minAD", Int(optional=True), default=2)
 
         self.step(
             "step1",
@@ -99,7 +100,9 @@ class Strelka2PassWorkflow(BioinformaticsWorkflow):
         self.step(
             "refilterSNVs",
             RefilterStrelka2Calls(
-                inputFiles=self.step2.snvs, sampleNames=self.sampleNames
+                inputFiles=self.step2.snvs,
+                sampleNames=self.sampleNames,
+                minAD=self.minAD,
             ),
         )
         self.step("compressSNVs", BGZip(file=self.refilterSNVs.out), scatter="file")

--- a/janis_bioinformatics/tools/gatk4/mutect2/base_4_1.py
+++ b/janis_bioinformatics/tools/gatk4/mutect2/base_4_1.py
@@ -96,7 +96,8 @@ class Gatk4Mutect2Base_4_1(Gatk4ToolBase, ABC):
             ),
             ToolInput(
                 tag="outputBamName",
-                input_type=Filename(extension=".bam"),
+                # This is not a FileName because otherwise we cant make this optional
+                input_type=String(optional=True),
                 prefix="-bamout",
                 doc="File to which assembled haplotypes should be written",
             ),
@@ -881,7 +882,7 @@ class Gatk4Mutect2Base_4_1(Gatk4ToolBase, ABC):
             ),
             ToolOutput(
                 "bam",
-                BamBai,
+                BamBai(optional=True),
                 glob=InputSelector("outputBamName"),
                 doc="File to which assembled haplotypes should be written",
                 secondaries_present_as={".bai": "^.bai"},


### PR DESCRIPTION
latest version of dawsontoolkit allows to specify the minimum allelic depth

also Mutect2 will not create a supporting haplotype bam by default now.