### PR TITLE
Bug fix: correctly parse adapter/contaminant sequence from fastqc

### DIFF
--- a/janis_bioinformatics/tools/babrahambioinformatics/fastqc/base.py
+++ b/janis_bioinformatics/tools/babrahambioinformatics/fastqc/base.py
@@ -151,7 +151,8 @@ class FastQCBase(BioinformaticsTool, ABC):
             ToolOutput(
                 "out_R2",
                 ZipFile(),
-                selector=InputSelector("read2", remove_file_extension=True),
+                selector=InputSelector("read2", remove_file_extension=True)
+                + "_fastqc.zip",
             ),
             ToolOutput(
                 "out_R2_datafile",

--- a/janis_bioinformatics/tools/babrahambioinformatics/fastqc/base.py
+++ b/janis_bioinformatics/tools/babrahambioinformatics/fastqc/base.py
@@ -3,7 +3,9 @@ import os
 from abc import ABC
 from datetime import datetime
 from typing import List, Dict, Any
+from janis_bioinformatics.data_types.fastq import FastqGzPair
 
+from janis_core.operators.operator import IndexOperator
 from janis_core import (
     ToolOutput,
     ToolInput,
@@ -17,6 +19,7 @@ from janis_core import (
     Int,
     CaptureType,
     CpuSelector,
+    InputSelector,
 )
 from janis_core import get_value_for_hints_and_ordered_resource_tuple
 from janis_core.tool.test_classes import (
@@ -24,9 +27,9 @@ from janis_core.tool.test_classes import (
     TTestExpectedOutput,
     TTestPreprocessor,
 )
-from janis_unix import ZipFile, TextFile
+from janis_unix import ZipFile, TextFile, HtmlFile
 
-from janis_bioinformatics.data_types import FastqGzPair, FastqGz
+from janis_bioinformatics.data_types import FastqGz
 from janis_bioinformatics.tools import BioinformaticsTool
 
 CORES_TUPLE = [
@@ -73,9 +76,9 @@ class FastQCBase(BioinformaticsTool, ABC):
 
     def bind_metadata(self):
         return ToolMetadata(
-            contributors=["Michael Franklin"],
+            contributors=["Michael Franklin", "Jiaan Yu"],
             dateCreated=datetime(2019, 3, 25),
-            dateUpdated=datetime(2019, 3, 25),
+            dateUpdated=datetime(2021, 11, 10),
             institution="Babraham Bioinformatics",
             doi=None,
             citation=None,
@@ -103,17 +106,69 @@ class FastQCBase(BioinformaticsTool, ABC):
         return 8
 
     def inputs(self) -> List[ToolInput]:
-        return [ToolInput("reads", Array(FastqGz), position=5), *self.additional_inputs]
+        return [
+            ToolInput("reads", FastqGzPair),
+            ToolInput(
+                "read1",
+                FastqGz(optional=True),
+                default=IndexOperator(InputSelector("reads"), 0),
+                position=5,
+            ),
+            ToolInput(
+                "read2",
+                FastqGz(optional=True),
+                default=IndexOperator(InputSelector("reads"), 1),
+                position=6,
+            ),
+            *self.additional_inputs,
+        ]
 
     def outputs(self) -> List[ToolOutput]:
         return [
             ToolOutput(
-                "out", Array(ZipFile()), glob=WildcardSelector(wildcard="*.zip")
+                "out_R1",
+                ZipFile(),
+                selector=InputSelector("read1", remove_file_extension=True)
+                + "_fastqc.zip",
             ),
             ToolOutput(
-                "datafile",
-                Array(File),
-                glob=WildcardSelector(wildcard="*/fastqc_data.txt"),
+                "out_R1_datafile",
+                File,
+                selector=InputSelector("read1", remove_file_extension=True)
+                + "_fastqc/fastqc_data.txt",
+            ),
+            ToolOutput(
+                "out_R1_html",
+                HtmlFile,
+                selector=InputSelector("read1", remove_file_extension=True)
+                + "_fastqc.html",
+            ),
+            ToolOutput(
+                "out_R1_directory",
+                Directory,
+                selector=InputSelector("read1", remove_file_extension=True) + "_fastqc",
+            ),
+            ToolOutput(
+                "out_R2",
+                ZipFile(),
+                selector=InputSelector("read2", remove_file_extension=True),
+            ),
+            ToolOutput(
+                "out_R2_datafile",
+                File,
+                selector=InputSelector("read2", remove_file_extension=True)
+                + "_fastqc/fastqc_data.txt",
+            ),
+            ToolOutput(
+                "out_R2_html",
+                HtmlFile,
+                selector=InputSelector("read2", remove_file_extension=True)
+                + "_fastqc.html",
+            ),
+            ToolOutput(
+                "out_R2_directory",
+                Directory,
+                selector=InputSelector("read2", remove_file_extension=True) + "_fastqc",
             ),
         ]
 

--- a/janis_bioinformatics/tools/babrahambioinformatics/fastqc/base.py
+++ b/janis_bioinformatics/tools/babrahambioinformatics/fastqc/base.py
@@ -1,9 +1,7 @@
 import operator
-import os
 from abc import ABC
 from datetime import datetime
 from typing import List, Dict, Any
-from janis_bioinformatics.data_types.fastq import FastqGzPair
 
 from janis_core.operators.operator import IndexOperator
 from janis_core import (
@@ -29,7 +27,7 @@ from janis_core.tool.test_classes import (
 )
 from janis_unix import ZipFile, TextFile, HtmlFile
 
-from janis_bioinformatics.data_types import FastqGz
+from janis_bioinformatics.data_types import FastqGz, FastqGzPair
 from janis_bioinformatics.tools import BioinformaticsTool
 
 CORES_TUPLE = [
@@ -315,15 +313,24 @@ class FastQCBase(BioinformaticsTool, ABC):
                     ],
                     "threads": 1,
                 },
-                output=FastqGzPair.basic_test("out", 824000, 408000, 416000)
-                + Array.array_wrapper(
-                    [
-                        TextFile.basic_test(
-                            "datafile",
-                            81000,
-                        )
-                    ]
-                ),
+                output=[
+                    TTestExpectedOutput(
+                        tag="out_R1_datafile",
+                        preprocessor=TTestPreprocessor.LineCount,
+                        operator=operator.eq,
+                        expected_value=2739,
+                    ),
+                    TTestExpectedOutput(
+                        tag="out_R2_datafile",
+                        preprocessor=TTestPreprocessor.LineCount,
+                        operator=operator.eq,
+                        expected_value=2751,
+                    ),
+                ]
+                + ZipFile.basic_test("out_R1", 400000)
+                + ZipFile.basic_test("out_R2", 400000)
+                + HtmlFile.basic_test("out_R1_html", 600000)
+                + HtmlFile.basic_test("out_R2_html", 600000),
             ),
             TTestCase(
                 name="minimal",

--- a/janis_bioinformatics/tools/babrahambioinformatics/fastqc/base.py
+++ b/janis_bioinformatics/tools/babrahambioinformatics/fastqc/base.py
@@ -1,4 +1,3 @@
-import operator
 from abc import ABC
 from datetime import datetime
 from typing import List, Dict, Any
@@ -131,7 +130,7 @@ class FastQCBase(BioinformaticsTool, ABC):
             ),
             ToolOutput(
                 "out_R1_datafile",
-                File,
+                TextFile,
                 selector=InputSelector("read1", remove_file_extension=True)
                 + "_fastqc/fastqc_data.txt",
             ),
@@ -154,7 +153,7 @@ class FastQCBase(BioinformaticsTool, ABC):
             ),
             ToolOutput(
                 "out_R2_datafile",
-                File,
+                TextFile,
                 selector=InputSelector("read2", remove_file_extension=True)
                 + "_fastqc/fastqc_data.txt",
             ),
@@ -313,20 +312,18 @@ class FastQCBase(BioinformaticsTool, ABC):
                     ],
                     "threads": 1,
                 },
-                output=[
-                    TTestExpectedOutput(
-                        tag="out_R1_datafile",
-                        preprocessor=TTestPreprocessor.LineCount,
-                        operator=operator.eq,
-                        expected_value=2739,
-                    ),
-                    TTestExpectedOutput(
-                        tag="out_R2_datafile",
-                        preprocessor=TTestPreprocessor.LineCount,
-                        operator=operator.eq,
-                        expected_value=2751,
-                    ),
-                ]
+                output=TextFile.basic_test(
+                    "out_R1_datafile",
+                    80000,
+                    line_count=2739,
+                    md5="8e23d29e0859ba547f0aa616ca395a8f",
+                )
+                + TextFile.basic_test(
+                    "out_R2_datafile",
+                    80000,
+                    line_count=2751,
+                    md5="a623b0a610ce51cef1137c7cb542f773",
+                )
                 + ZipFile.basic_test("out_R1", 400000)
                 + ZipFile.basic_test("out_R2", 400000)
                 + HtmlFile.basic_test("out_R1_html", 600000)

--- a/janis_bioinformatics/tools/common/bwaaligner.py
+++ b/janis_bioinformatics/tools/common/bwaaligner.py
@@ -35,20 +35,20 @@ class BwaAligner(BioinformaticsWorkflow):
         self.input("fastq", FastqGzPair)
 
         # pipe adapters
-        self.input("three_prim_adapter_read1", Array(str, optional=True))
-        self.input("three_prim_adapter_read2", Array(str, optional=True))
-        self.input("five_prim_adapter_read1", Array(str, optional=True))
-        self.input("five_prim_adapter_read2", Array(str, optional=True))
+        self.input("three_prime_adapter_read1", Array(str, optional=True))
+        self.input("three_prime_adapter_read2", Array(str, optional=True))
+        self.input("five_prime_adapter_read1", Array(str, optional=True))
+        self.input("five_prime_adapter_read2", Array(str, optional=True))
 
         # Steps
         self.step(
             "cutadapt",
             CutAdapt_2_1(
                 fastq=self.fastq,
-                adapter=self.three_prim_adapter_read1,
-                adapterSecondRead=self.three_prim_adapter_read2,
-                front=self.five_prim_adapter_read1,
-                frontAdapterSecondRead=self.five_prim_adapter_read2,
+                adapter=self.three_prime_adapter_read1,
+                adapterSecondRead=self.three_prime_adapter_read2,
+                front=self.five_prime_adapter_read1,
+                frontAdapterSecondRead=self.five_prime_adapter_read2,
                 qualityCutoff=15,
                 minimumLength=50,
                 outputPrefix=self.sample_name,

--- a/janis_bioinformatics/tools/common/bwaaligner.py
+++ b/janis_bioinformatics/tools/common/bwaaligner.py
@@ -26,7 +26,7 @@ class BwaAligner(BioinformaticsWorkflow):
         return "common"
 
     def version(self):
-        return "1.0.0"
+        return "1.2.0"
 
     def constructor(self):
         # Inputs
@@ -35,18 +35,20 @@ class BwaAligner(BioinformaticsWorkflow):
         self.input("fastq", FastqGzPair)
 
         # pipe adapters
-        self.input("cutadapt_adapter", Array(str, optional=True))
-        self.input("cutadapt_removeMiddle3Adapter", Array(str, optional=True))
+        self.input("three_prim_adapter_read1", Array(str, optional=True))
+        self.input("three_prim_adapter_read2", Array(str, optional=True))
+        self.input("five_prim_adapter_read1", Array(str, optional=True))
+        self.input("five_prim_adapter_read2", Array(str, optional=True))
 
         # Steps
         self.step(
             "cutadapt",
             CutAdapt_2_1(
                 fastq=self.fastq,
-                adapter=self.cutadapt_adapter,
-                front=None,
-                removeMiddle5Adapter=None,
-                removeMiddle3Adapter=self.cutadapt_removeMiddle3Adapter,
+                adapter=self.three_prim_adapter_read1,
+                adapterSecondRead=self.three_prim_adapter_read2,
+                front=self.five_prim_adapter_read1,
+                frontAdapterSecondRead=self.five_prim_adapter_read2,
                 qualityCutoff=15,
                 minimumLength=50,
                 outputPrefix=self.sample_name,
@@ -80,9 +82,10 @@ class BwaAligner(BioinformaticsWorkflow):
 
     def bind_metadata(self):
         self.metadata.documentation = "Align sorted bam with this subworkflow consisting of BWA Mem + SamTools + Gatk4SortSam"
-        self.metadata.contributors = ["Michael Franklin"]
+        self.metadata.contributors = ["Michael Franklin", "Jiaan Yu"]
         self.metadata.dateCreated = "2018-12-24"
-        self.metadata.version = "1.1"
+        self.metadata.dateUpdated = "2021-11-03"
+        self.metadata.version = "1.2"
 
     def tests(self):
         remote_dir = "https://swift.rc.nectar.org.au/v1/AUTH_4df6e734a509497692be237549bbe9af/janis-test-data/bioinformatics/wgsgermline_data"

--- a/janis_bioinformatics/tools/cutadapt/base_2.py
+++ b/janis_bioinformatics/tools/cutadapt/base_2.py
@@ -138,14 +138,14 @@ class CutAdaptBase_2(BioinformaticsTool):
         ),
         ToolInput(
             tag="front",
-            input_type=String(optional=True),
+            input_type=Array(String(), optional=True),
             prefix="--front",
             separate_value_from_prefix=True,
             doc="(-g)  Sequence of an adapter ligated to the 5' end (paired data: of the first read). The adapter and any preceding bases are trimmed. Partial matches at the 5' end are allowed. If a '^' character is prepended ('anchoring'), the adapter is only found if it is a prefix of the read.",
         ),
         ToolInput(
             tag="anywhere",
-            input_type=String(optional=True),
+            input_type=Array(String(), optional=True),
             prefix="--anywhere",
             separate_value_from_prefix=True,
             doc="(-b)  Sequence of an adapter that may be ligated to the 5' or 3' end (paired data: of the first read). Both types of matches as described under -a und -g are allowed. If the first base of the read is part of the match, the behavior is as with -g, otherwise as with -a. This option is mostly for rescuing failed library preparations - do not use if you know which end your adapter was ligated to!",
@@ -375,7 +375,7 @@ class CutAdaptBase_2(BioinformaticsTool):
             doc=" Write reads that do not contain any adapter to FILE. Default: output to same file as trimmed reads",
         ),
         ToolInput(
-            tag="removeMiddle3Adapter",
+            tag="adapterSecondRead",
             input_type=Array(String, optional=True),
             prefix="-A",
             separate_value_from_prefix=True,
@@ -383,15 +383,15 @@ class CutAdaptBase_2(BioinformaticsTool):
             doc="3' adapter to be removed from second read in a pair.",
         ),
         ToolInput(
-            tag="removeMiddle5Adapter",
-            input_type=String(optional=True),
+            tag="frontAdapterSecondRead",
+            input_type=Array(String, optional=True),
             prefix="-G",
             separate_value_from_prefix=True,
             doc="5' adapter to be removed from second read in a pair.",
         ),
         ToolInput(
-            tag="removeMiddleBothAdapter",
-            input_type=String(optional=True),
+            tag="anywhereAdapterSecondRead",
+            input_type=Array(String, optional=True),
             prefix="-B",
             separate_value_from_prefix=True,
             doc="5'/3 adapter to be removed from second read in a pair.",
@@ -405,7 +405,7 @@ class CutAdaptBase_2(BioinformaticsTool):
         ),
         ToolInput(
             tag="pairAdapters",
-            input_type=String(optional=True),
+            input_type=Boolean(optional=True),
             prefix="--pair-adapters",
             separate_value_from_prefix=True,
             doc="Treat adapters given with -a/-A etc. as pairs. Either both or none are removed from each read pair.",
@@ -449,9 +449,9 @@ class CutAdaptBase_2(BioinformaticsTool):
 
     def bind_metadata(self):
         return ToolMetadata(
-            contributors=["Michael Franklin"],
+            contributors=["Michael Franklin", "Jiaan Yu"],
             dateCreated=datetime(2019, 3, 21),
-            dateUpdated=datetime(2019, 7, 23),
+            dateUpdated=datetime(2021, 11, 3),
             institution=None,
             doi="DOI:10.14806/ej.17.1.200",
             citation="Martin, Marcel. “Cutadapt Removes Adapter Sequences from High-Throughput Sequencing Reads.” "

--- a/janis_bioinformatics/tools/illumina/manta/base.py
+++ b/janis_bioinformatics/tools/illumina/manta/base.py
@@ -11,6 +11,7 @@ from janis_core import (
     Filename,
     InputSelector,
     Int,
+    MemorySelector,
     String,
     StringFormatter,
     ToolArgument,
@@ -143,6 +144,15 @@ class MantaBase(IlluminaToolBase, ABC):
                 prefix="-j",
                 doc="(-j) number of jobs, must be an integer or 'unlimited' "
                 "(default: Estimate total cores on this node for local mode, 128 for sge mode)",
+            ),
+            ToolArgument(
+                MemorySelector(),
+                prefix="--memGb",
+                position=3,
+                shell_quote=False,
+                doc=" (-g MEMGB) gigabytes of memory available to run workflow "
+                "-- only meaningful in local mode, must be an integer (default: Estimate the total "
+                "memory for this node for local mode, 'unlimited' for sge mode)",
             ),
         ]
 
@@ -299,16 +309,6 @@ of capabilities and limitations.""".strip(),
             position=3,
             shell_quote=False,
             doc="(-q) specify scheduler queue name",
-        ),
-        ToolInput(
-            "memgb",
-            Int(optional=True),
-            prefix="--memGb",
-            position=3,
-            shell_quote=False,
-            doc="(-g) gigabytes of memory available to run workflow -- only meaningful in local mode, "
-            "must be an integer (default: Estimate the total memory for this node for local  mode, "
-            "'unlimited' for sge mode)",
         ),
         # ToolInput("dryRun", Boolean(optional=True), prefix="--dryRun", position=3, shell_quote=False,
         #           doc="(-d) dryRun workflow code without actually running command - tasks"),

--- a/janis_bioinformatics/tools/illumina/strelkagermline/base.py
+++ b/janis_bioinformatics/tools/illumina/strelkagermline/base.py
@@ -1,7 +1,6 @@
 from abc import ABC
 from typing import List, Any, Dict
 
-from janis_core import CpuSelector
 from janis_core import (
     ToolOutput,
     ToolInput,
@@ -13,6 +12,8 @@ from janis_core import (
     CaptureType,
     StringFormatter,
     ToolMetadata,
+    CpuSelector,
+    MemorySelector,
 )
 from janis_core import get_value_for_hints_and_ordered_resource_tuple
 from janis_unix import Tsv
@@ -222,16 +223,6 @@ class StrelkaGermlineBase(IlluminaToolBase, ABC):
                 shell_quote=False,
                 doc="(-q QUEUE) specify scheduler queue name",
             ),
-            ToolInput(
-                "memGb",
-                String(optional=True),
-                prefix="--memGb",
-                position=3,
-                shell_quote=False,
-                doc=" (-g MEMGB) gigabytes of memory available to run workflow "
-                "-- only meaningful in local mode, must be an integer (default: Estimate the total "
-                "memory for this node for local mode, 'unlimited' for sge mode)",
-            ),
             # ToolInput("dryRun", Boolean(optional=True), prefix="--dryRun", position=3, shell_quote=False,
             #           doc="dryRun (-d,) workflow code without actually running command-tasks"),
             ToolInput(
@@ -310,6 +301,15 @@ class StrelkaGermlineBase(IlluminaToolBase, ABC):
                 shell_quote=False,
                 doc=" (-j JOBS)  number of jobs, must be an integer or 'unlimited' "
                 "(default: Estimate total cores on this node for local mode, 128 for sge mode)",
+            ),
+            ToolArgument(
+                MemorySelector(),
+                prefix="--memGb",
+                position=3,
+                shell_quote=False,
+                doc=" (-g MEMGB) gigabytes of memory available to run workflow "
+                "-- only meaningful in local mode, must be an integer (default: Estimate the total "
+                "memory for this node for local mode, 'unlimited' for sge mode)",
             ),
         ]
 

--- a/janis_bioinformatics/tools/illumina/strelkasomatic/base.py
+++ b/janis_bioinformatics/tools/illumina/strelkasomatic/base.py
@@ -13,6 +13,7 @@ from janis_core import (
     Filename,
     InputSelector,
     Int,
+    MemorySelector,
     String,
     StringFormatter,
     ToolArgument,
@@ -89,6 +90,15 @@ class StrelkaSomaticBase(IlluminaToolBase, ABC):
                 shell_quote=False,
                 doc=" (-j JOBS)  number of jobs, must be an integer or 'unlimited' "
                 "(default: Estimate total cores on this node for local mode, 128 for sge mode)",
+            ),
+            ToolArgument(
+                MemorySelector(),
+                prefix="--memGb",
+                position=3,
+                shell_quote=False,
+                doc=" (-g MEMGB) gigabytes of memory available to run workflow "
+                "-- only meaningful in local mode, must be an integer (default: Estimate the total "
+                "memory for this node for local mode, 'unlimited' for sge mode)",
             ),
         ]
 
@@ -304,16 +314,6 @@ class StrelkaSomaticBase(IlluminaToolBase, ABC):
                 position=3,
                 shell_quote=False,
                 doc="(-q QUEUE) specify scheduler queue name",
-            ),
-            ToolInput(
-                "memGb",
-                String(optional=True),
-                prefix="--memGb",
-                position=3,
-                shell_quote=False,
-                doc=" (-g MEMGB) gigabytes of memory available to run workflow "
-                "-- only meaningful in local mode, must be an integer (default: Estimate the total "
-                "memory for this node for local mode, 'unlimited' for sge mode)",
             ),
             ToolInput(
                 "quiet",

--- a/janis_bioinformatics/tools/pmac/__init__.py
+++ b/janis_bioinformatics/tools/pmac/__init__.py
@@ -1,5 +1,6 @@
 from .combinevariants.versions import *
 from .trimiupac.versions import *
+from .parsefastqc.v0_1_0 import ParseFastqcAdaptors
 from .parsefastqc.v0_2_0 import ParseFastqcAdapters
 from .performancesummary.versions import *
 from .genecovpersample.versions import *

--- a/janis_bioinformatics/tools/pmac/__init__.py
+++ b/janis_bioinformatics/tools/pmac/__init__.py
@@ -1,5 +1,7 @@
 from .combinevariants.versions import *
 from .trimiupac.versions import *
+
+# Keep the old tool ParseFastqcAdaptors from breaking the other pipelines
 from .parsefastqc.v0_1_0 import ParseFastqcAdaptors
 from .parsefastqc.v0_2_0 import ParseFastqcAdapters
 from .performancesummary.versions import *

--- a/janis_bioinformatics/tools/pmac/__init__.py
+++ b/janis_bioinformatics/tools/pmac/__init__.py
@@ -1,6 +1,6 @@
 from .combinevariants.versions import *
 from .trimiupac.versions import *
-from .parsefastqc.v0_1_0 import ParseFastqcAdaptors
+from .parsefastqc.v0_2_0 import ParseFastqcAdaptors
 from .performancesummary.versions import *
 from .genecovpersample.versions import *
 from .addsymtodepthofcoverage.versions import *

--- a/janis_bioinformatics/tools/pmac/__init__.py
+++ b/janis_bioinformatics/tools/pmac/__init__.py
@@ -1,6 +1,6 @@
 from .combinevariants.versions import *
 from .trimiupac.versions import *
-from .parsefastqc.v0_2_0 import ParseFastqcAdaptors
+from .parsefastqc.v0_2_0 import ParseFastqcAdapters
 from .performancesummary.versions import *
 from .genecovpersample.versions import *
 from .addsymtodepthofcoverage.versions import *

--- a/janis_bioinformatics/tools/pmac/parsefastqc/v0_2_0.py
+++ b/janis_bioinformatics/tools/pmac/parsefastqc/v0_2_0.py
@@ -1,0 +1,186 @@
+"""
+Each modification of this tool should duplicate this code
+"""
+import operator
+import os
+from datetime import datetime
+from typing import List, Dict, Any, Optional
+
+from janis_core import PythonTool, File, Array, ToolMetadata
+from janis_core.tool.test_classes import (
+    TTestCase,
+    TTestExpectedOutput,
+    TTestPreprocessor,
+)
+from janis_core.tool.tool import TOutput
+
+from janis_bioinformatics.tools.bioinformaticstoolbase import BioinformaticsPythonTool
+from janis_bioinformatics.tools import BioinformaticsTool
+
+
+class ParseFastqcAdaptors(BioinformaticsPythonTool):
+    @staticmethod
+    def code_block(
+        fastqc_datafiles: List[File], cutadapt_adaptors_lookup: Optional[File]
+    ):
+        """
+
+        :param fastqc_datafiles:
+
+        :param cutadapt_adaptors_lookup: Specifies a file which contains the list of adapter sequences which will
+            be explicity searched against the library. The file must contain sets of named adapters in
+            the form name[tab]sequence. Lines prefixed with a hash will be ignored.
+        :return:
+        """
+        if not cutadapt_adaptors_lookup:
+            return {"adaptor_sequences": []}
+
+        import mmap, re, csv
+        from io import StringIO
+        from sys import stderr
+
+        def get_overrepresented_text(f):
+            """
+            Get the table "Overrepresented sequences" within the fastqc_data.txt
+            """
+            adapt_section_query = (
+                br"(?s)>>Overrepresented sequences\t\S+\n(.*?)>>END_MODULE"
+            )
+            # fastqc_datafile could be fairly large, so we'll use mmap, and then
+            with open(f) as f, mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as fp:
+                overrepresented_sequences_match = re.search(adapt_section_query, fp)
+                if overrepresented_sequences_match is None:
+                    raise Exception(
+                        f"Couldn't find query ('{adapt_section_query.decode('utf8')}') in {fastqc_datafiles}"
+                    )
+
+                return overrepresented_sequences_match.groups()[0].decode("utf8")
+
+        def parse_tsv_table(tbl: str, skip_headers):
+            """
+            Parse a TSV table from a string using csvreader
+            """
+
+            rd = csv.reader(StringIO(tbl), delimiter="\t", quotechar='"')
+            ret = list(rd)
+            if len(ret) == 0:
+                return ret
+            if skip_headers:
+                ret.pop(0)  # discard headers
+            return ret
+
+        def get_cutadapt_map():
+            """
+            Helper method to parse the file 'cutadapt_adaptors_lookup' with
+            format: 'name[tab]sequence' into the dictionary: '{ sequence: name }'
+            """
+            cutadapt_map = {}
+            with open(cutadapt_adaptors_lookup) as fp:
+                for row in fp:
+                    st = row.strip()
+                    if not st or st.startswith("#"):
+                        continue
+
+                    # In reality, the format is $name[\t+]$seqence (more than one tab)
+                    # so we'll just split on a tab, and remove all the empty elements.
+                    split = [f for f in st.split("\t") if bool(f) and len(f) > 0]
+
+                    # Invalid format for line, so skip it.
+                    if len(split) != 2:
+                        print(
+                            f"Skipping cutadapt line '{st}' as irregular elements ({len(split)})",
+                            file=stderr,
+                        )
+                        continue
+
+                    # reverse the order from name[tab]sequence to { sequence: tab }
+                    cutadapt_map[split[0]] = split[1]
+            return cutadapt_map
+
+        # Start doing the work
+        # Look up overrepresented sequences
+        overrepresented_sequences = set()
+        for fastqcfile in fastqc_datafiles:
+            text = get_overrepresented_text(fastqcfile)
+            overrepresented_sequences = overrepresented_sequences.union(
+                set(a[0] for a in parse_tsv_table(text, skip_headers=True))
+            )
+
+        # Look up adaptor sequences
+        adaptor_sequences = []
+        adaptor_status = False
+        for fastqcfile in fastqc_datafiles:
+            for line in open(fastqcfile, "r"):
+                if line.startswith(">>Adapter Content"):
+                    adaptor_qc_line = line
+                    adaptor_status = True
+                elif adaptor_status == False:
+                    continue
+                elif adaptor_status == True and not line.startswith(">>END_MODULE"):
+                    if line.startswith("#Position"):
+                        adaptor_list = line.strip("\n").split("\t")
+                    else:
+                        adaptor_percentage = line.strip("\n").split("\t")
+
+            # Parse adaptor id if adaptor qc fails
+            if "fail" in adaptor_qc_line:
+                cutadapt_map = get_cutadapt_map()
+                for (aid, percentage) in zip(adaptor_list[1:], adaptor_percentage[1:]):
+                    if float(percentage) >= 10:
+                        if aid in cutadapt_map:
+                            sequence = cutadapt_map.get(aid)
+                            print(
+                                f"Identified adaptor '{aid}' sequence '{sequence}' in lookup",
+                                file=stderr,
+                            )
+                            adaptor_sequences.append(sequence)
+                        else:
+                            print(
+                                f"Couldn't find a corresponding sequence for '{aid}' in lookup map",
+                                file=stderr,
+                            )
+            else:
+                pass
+
+        return {
+            "adaptor_sequences": list(overrepresented_sequences) + adaptor_sequences
+        }
+
+    def outputs(self) -> List[TOutput]:
+        return [TOutput("adaptor_sequences", Array(str))]
+
+    def id(self) -> str:
+        return "ParseFastqcAdaptors"
+
+    def friendly_name(self):
+        return "Parse FastQC Adaptors"
+
+    def version(self):
+        return "v0.2.0"
+
+    def tool_provider(self):
+        return "Peter MacCallum Cancer Centre"
+
+    def bind_metadata(self):
+        self.metadata.documentation = (
+            "Parse overrepresented region and lookup in Cutadapt table"
+        )
+        self.metadata.contributors = ["Michael Franklin", "Jiaan Yu"]
+        self.metadata.dateCreated = datetime(2020, 1, 7)
+        self.metadata.dateUpdated = datetime(2021, 10, 6)
+        self.metadata.version = "0.1.0"
+
+    def tests(self):
+        remote_dir = "https://swift.rc.nectar.org.au/v1/AUTH_4df6e734a509497692be237549bbe9af/janis-test-data/bioinformatics/wgsgermline_data"
+        return [
+            TTestCase(
+                name="basic",
+                input={
+                    "fastqc_datafiles": [
+                        f"{remote_dir}/NA12878-BRCA1.fastqc_data.txt",
+                    ],
+                    "cutadapt_adaptors_lookup": f"{remote_dir}/contaminant_list.txt",
+                },
+                output=[],
+            ),
+        ]

--- a/janis_bioinformatics/tools/pmac/parsefastqc/v0_2_0.py
+++ b/janis_bioinformatics/tools/pmac/parsefastqc/v0_2_0.py
@@ -15,16 +15,16 @@ from janis_core.tool.test_classes import (
 from janis_bioinformatics.tools.bioinformaticstoolbase import BioinformaticsPythonTool
 
 
-class ParseFastqcAdaptors(BioinformaticsPythonTool):
+class ParseFastqcAdapters(BioinformaticsPythonTool):
     @staticmethod
     def code_block(
-        fastqc_datafiles: List[File], adaptors_lookup: File, contamination_lookup: File
+        fastqc_datafiles: List[File], adapters_lookup: File, contamination_lookup: File
     ):
         """
 
         :param fastqc_datafiles: Array of files, fastqc_datafiles of read 1 and read 2, respectively
 
-        :param adaptors_lookup: Specifies a file which contains the list of adapter sequences which will
+        :param adapters_lookup: Specifies a file which contains the list of adapter sequences which will
             be explicity searched against the library. The file must contain sets of named adapters in
             the form name[tab]sequence. Lines prefixed with a hash will be ignored.
 
@@ -79,7 +79,7 @@ class ParseFastqcAdaptors(BioinformaticsPythonTool):
 
         def get_adapt_map(adapter_file):
             """
-            Helper method to parse the file 'adaptors_lookup'/ 'contamination_lookup' with
+            Helper method to parse the file 'adapters_lookup'/ 'contamination_lookup' with
             format: 'name[tab]sequence' into the dictionary: '{ name: sequence }'
             """
             adapter_map = {}
@@ -96,7 +96,7 @@ class ParseFastqcAdaptors(BioinformaticsPythonTool):
                     # Invalid format for line, so skip it.
                     if len(split) != 2:
                         print(
-                            f"Skipping adaptor line '{st}' as irregular elements ({len(split)})",
+                            f"Skipping adapter line '{st}' as irregular elements ({len(split)})",
                             file=stderr,
                         )
                         continue
@@ -140,33 +140,33 @@ class ParseFastqcAdaptors(BioinformaticsPythonTool):
                             file=stderr,
                         )
 
-            # Look up common adaptor sequences
-            adaptor_sequences = []
-            adaptor_status = False
+            # Look up common adapter sequences
+            adapter_sequences = []
+            adapter_status = False
             for line in open(qc_file, "r"):
                 if line.startswith(">>Adapter Content"):
-                    adaptor_qc_line = line
-                    adaptor_status = True
-                elif adaptor_status == False:
+                    adapter_qc_line = line
+                    adapter_status = True
+                elif adapter_status == False:
                     continue
-                elif adaptor_status == True and not line.startswith(">>END_MODULE"):
+                elif adapter_status == True and not line.startswith(">>END_MODULE"):
                     if line.startswith("#Position"):
-                        adaptor_names = line.strip("\n").split("\t")
+                        adapter_names = line.strip("\n").split("\t")
                     else:
-                        adaptor_vals = line.strip("\n").split("\t")
+                        adapter_vals = line.strip("\n").split("\t")
 
-            # Parse adaptor id if adaptor qc fails
-            if "fail" in adaptor_qc_line:
-                adapter_map = get_adapt_map(adaptors_lookup)
-                for (aid, percentage) in zip(adaptor_names[1:], adaptor_vals[1:]):
+            # Parse adapter id if adapter qc fails
+            if "fail" in adapter_qc_line:
+                adapter_map = get_adapt_map(adapters_lookup)
+                for (aid, percentage) in zip(adapter_names[1:], adapter_vals[1:]):
                     if float(percentage) >= 10:
                         if aid in adapter_map:
                             sequence = adapter_map.get(aid)
                             print(
-                                f"Identified adaptor '{aid}' sequence '{sequence}' in lookup",
+                                f"Identified adapter '{aid}' sequence '{sequence}' in lookup",
                                 file=stderr,
                             )
-                            adaptor_sequences.append(sequence)
+                            adapter_sequences.append(sequence)
                         else:
                             print(
                                 f"Couldn't find a corresponding sequence for '{aid}' in lookup map",
@@ -176,9 +176,9 @@ class ParseFastqcAdaptors(BioinformaticsPythonTool):
                 pass
 
             if i == 0:
-                read1_sequences = list(overrepresented_sequences) + adaptor_sequences
+                read1_sequences = list(overrepresented_sequences) + adapter_sequences
             else:
-                read2_sequences = list(overrepresented_sequences) + adaptor_sequences
+                read2_sequences = list(overrepresented_sequences) + adapter_sequences
             i += 1
 
         return {
@@ -193,10 +193,10 @@ class ParseFastqcAdaptors(BioinformaticsPythonTool):
         ]
 
     def id(self) -> str:
-        return "ParseFastqcAdaptors"
+        return "ParseFastqcAdapters"
 
     def friendly_name(self):
-        return "Parse FastQC Adaptors"
+        return "Parse FastQC Adapters"
 
     def version(self):
         return "v0.2.0"
@@ -206,7 +206,7 @@ class ParseFastqcAdaptors(BioinformaticsPythonTool):
 
     def bind_metadata(self):
         self.metadata.documentation = (
-            "Parse overrepresented region and lookup in adaptor table"
+            "Parse overrepresented region and lookup in adapter table"
         )
         self.metadata.contributors = ["Michael Franklin", "Jiaan Yu"]
         self.metadata.dateCreated = datetime(2020, 1, 7)
@@ -224,7 +224,7 @@ class ParseFastqcAdaptors(BioinformaticsPythonTool):
 #                 "fastqc_datafile": [
 #                     f"{remote_dir}/NA12878-BRCA1.fastqc_data.txt",
 #                 ],
-#                 "adaptors_lookup": f"{remote_dir}/contaminant_list.txt",
+#                 "adapters_lookup": f"{remote_dir}/contaminant_list.txt",
 #             },
 #             output=[],
 #         ),

--- a/janis_bioinformatics/tools/pmac/parsefastqc/v0_2_0.py
+++ b/janis_bioinformatics/tools/pmac/parsefastqc/v0_2_0.py
@@ -213,19 +213,19 @@ class ParseFastqcAdapters(BioinformaticsPythonTool):
         self.metadata.dateUpdated = datetime(2021, 10, 6)
         self.metadata.version = "0.2.0"
 
-
-# Unit test will fail
-# def tests(self):
-#     remote_dir = "https://swift.rc.nectar.org.au/v1/AUTH_4df6e734a509497692be237549bbe9af/janis-test-data/bioinformatics/wgsgermline_data"
-#     return [
-#         TTestCase(
-#             name="basic",
-#             input={
-#                 "fastqc_datafile": [
-#                     f"{remote_dir}/NA12878-BRCA1.fastqc_data.txt",
-#                 ],
-#                 "adapters_lookup": f"{remote_dir}/contaminant_list.txt",
-#             },
-#             output=[],
-#         ),
-#     ]
+    def tests(self):
+        # New files needed to update to the space
+        # Test not founding anything useful
+        remote_dir = "https://swift.rc.nectar.org.au/v1/AUTH_4df6e734a509497692be237549bbe9af/janis-test-data/bioinformatics/wgsgermline_data"
+        return [
+            TTestCase(
+                name="basic",
+                input={
+                    "read1_fastqc_datafile": f"{remote_dir}/NA12878-BRCA1_R1.fastqc_data.txt",
+                    "read2_fastqc_datafile": f"{remote_dir}/NA12878-BRCA1_R2.fastqc_data.txt",
+                    "adapters_lookup": f"{remote_dir}/adapter_list.txt",
+                    "contamination_lookup": f"{remote_dir}/contaminant_list.txt",
+                },
+                output=[],
+            ),
+        ]

--- a/janis_bioinformatics/tools/pmac/parsefastqc/v0_2_0.py
+++ b/janis_bioinformatics/tools/pmac/parsefastqc/v0_2_0.py
@@ -18,11 +18,15 @@ from janis_bioinformatics.tools.bioinformaticstoolbase import BioinformaticsPyth
 class ParseFastqcAdapters(BioinformaticsPythonTool):
     @staticmethod
     def code_block(
-        fastqc_datafiles: List[File], adapters_lookup: File, contamination_lookup: File
+        read1_fastqc_datafile: File,
+        read2_fastqc_datafile: File,
+        adapters_lookup: File,
+        contamination_lookup: File,
     ):
         """
+        :param read1_fastqc_datafile: fastqc_datafile of read 1
 
-        :param fastqc_datafiles: Array of files, fastqc_datafiles of read 1 and read 2, respectively
+        :param read2_fastqc_datafile: fastqc_datafile of read 2
 
         :param adapters_lookup: Specifies a file which contains the list of adapter sequences which will
             be explicity searched against the library. The file must contain sets of named adapters in
@@ -104,13 +108,9 @@ class ParseFastqcAdapters(BioinformaticsPythonTool):
             return adapter_map
 
         # Start doing the work
-        # Only works for PE data
-        if not len(fastqc_datafiles) == 2:
-            sys.exit()
-
         # Look up overrepresented sequences
         i = 0
-        for qc_file in fastqc_datafiles:
+        for qc_file in [read1_fastqc_datafile, read2_fastqc_datafile]:
             overrepresented_ids = set()
             overrepresented_sequences = []
             text = get_overrepresented_text(qc_file)
@@ -182,14 +182,14 @@ class ParseFastqcAdapters(BioinformaticsPythonTool):
             i += 1
 
         return {
-            "read1_sequences": read1_sequences,
-            "read2_sequences": read2_sequences,
+            "out_R1_sequences": read1_sequences,
+            "out_R2_sequences": read2_sequences,
         }
 
     def outputs(self) -> List[TOutput]:
         return [
-            TOutput("read1_sequences", Array(str)),
-            TOutput("read2_sequences", Array(str)),
+            TOutput("out_R1_sequences", Array(str)),
+            TOutput("out_R2_sequences", Array(str)),
         ]
 
     def id(self) -> str:


### PR DESCRIPTION
Breaking changes:
 - New tool ParseFastqcAdapters replacing ParseFastqcAdaptors, both are kept in the tool registry
from .parsefastqc.v0_1_0 import ParseFastqcAdaptors
from .parsefastqc.v0_2_0 import ParseFastqcAdapters - New
- Tool Cutadapt: some of the arguments, inputs, outputs id are changed
- Tool Fastqc: inputs and outputs are changed for better filename selection
- Tool BwaAligner:  some of the input arguments and internal arguments are changed


Added or modified unit tests for 
- ParseFastqcAdapters
- Fastqc

Unit test for BwaAligner and Cutadapt are not needed for change.

Illumina related tools - manta and strelka:
- Add memory selector as input, which is not available previously