### PR TITLE
remove the intermediate sample names for refiltering

### DIFF
--- a/janis_bioinformatics/tools/dawson/workflows/variantcalling/multisample/strelka2/strelka2passworkflow.py
+++ b/janis_bioinformatics/tools/dawson/workflows/variantcalling/multisample/strelka2/strelka2passworkflow.py
@@ -146,7 +146,6 @@ class Strelka2PassWorkflow(BioinformaticsWorkflow):
             "refilterSNVs",
             RefilterStrelka2Calls(
                 inputFiles=self.step2.snvs,
-                sampleNames=self.sampleNames,
                 minAD=self.minAD,
             ),
         )
@@ -157,7 +156,6 @@ class Strelka2PassWorkflow(BioinformaticsWorkflow):
             "refilterINDELs",
             RefilterStrelka2Calls(
                 inputFiles=self.step2.indels,
-                sampleNames=self.sampleNames,
                 minAD=self.minAD,
             ),
         )

--- a/janis_bioinformatics/tools/dawson/workflows/variantcalling/multisample/strelka2/strelka2passworkflow.py
+++ b/janis_bioinformatics/tools/dawson/workflows/variantcalling/multisample/strelka2/strelka2passworkflow.py
@@ -27,7 +27,7 @@ class Strelka2PassWorkflow(BioinformaticsWorkflow):
     def bind_metadata(self):
         self.metadata.version = "0.2"
         self.metadata.dateCreated = date(2019, 10, 11)
-        self.metadata.dateUpdated = date(2020, 12, 10)
+        self.metadata.dateUpdated = date(2022, 05, 31)
 
         self.metadata.contributors = ["Sebastian Hollizeck"]
         self.metadata.keywords = [

--- a/janis_bioinformatics/tools/dawson/workflows/variantcalling/multisample/strelka2/strelka2passworkflow.py
+++ b/janis_bioinformatics/tools/dawson/workflows/variantcalling/multisample/strelka2/strelka2passworkflow.py
@@ -27,7 +27,7 @@ class Strelka2PassWorkflow(BioinformaticsWorkflow):
     def bind_metadata(self):
         self.metadata.version = "0.2"
         self.metadata.dateCreated = date(2019, 10, 11)
-        self.metadata.dateUpdated = date(2022, 05, 31)
+        self.metadata.dateUpdated = date(2022, 5, 31)
 
         self.metadata.contributors = ["Sebastian Hollizeck"]
         self.metadata.keywords = [


### PR DESCRIPTION
Bugfix: lexicographical sorting of files when using sample names in glob* 

without sample names, the program underlying the step will automatically generate sample names which are ordered the right way.

